### PR TITLE
Use `list_ods_sheets` instead

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,6 @@ Imports:
     dplyr,
     tidyr,
     plyr (>= 1.8.4),
-    readODS (>= 1.6.4),
+    readODS (>= 1.7.0),
     readxl (>= 1.0.0)
 RoxygenNote: 7.1.1

--- a/R/convert_esaps.R
+++ b/R/convert_esaps.R
@@ -116,7 +116,7 @@ convert_esaps<-function(path = NULL,
                 if(isTRUE(allSheet)){
                         nSheets <- vector("numeric", length = length(file.name))
                         for(i in 1:length(file.name)){
-                                nSheets[i] <- length(readODS::ods_sheets(file.name[i]))
+                                nSheets[i] <- length(readODS::list_ods_sheets(file.name[i]))
                         }
                 }
                 dat <- list()


### PR DESCRIPTION
`readODS::ods_sheets` has been superseded by
`readODS::list_ods_sheets` since version 1.7.0 (2020-07-10) and will be removed in the upcoming readODS v2.0.0 (probably will be on CRAN next month).

Sorry for introducing this breaking change.